### PR TITLE
Fix Windows 'illegal token' (and others) errors

### DIFF
--- a/coin/src/db.cpp
+++ b/coin/src/db.cpp
@@ -376,7 +376,7 @@ bool db::rewrite(const std::string & file_name, const char * key_skip)
                     
                     if (
                         key_skip && std::strncmp(key.data(), key_skip,
-                        std::min(key.size(), std::strlen(key_skip))) == 0
+                        (std::min)(key.size(), std::strlen(key_skip))) == 0
                         )
                     {
                         continue;


### PR DESCRIPTION
Related to windows.h, as it seems to have made min/max into their own macros

---

There is still an issue with [db_env](https://github.com/openvcash/vcash/blob/master/coin/src/db_env.cpp#L205) preventing Windows cmake from building (triggers the only 2 errors I get now), but I don't have the fix for that yet.